### PR TITLE
AVR build system overhaul plus functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 # Print the help message #
 .PHONY: help
 help:
-	@echo "Embedlib build system."
+	@echo "Junk build system."
 	@echo "For more build system information see the readme.md"
 	@echo "Make targets:"
 	@echo "    all        Invokes `build`."

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Junk
 A library containing a random assortment of useful embedded code. This includes a HAL with drivers
 for AVR and STM32 parts as well as general use code such as memory, math, and container objects and
 functions.
+
+JunkHAL
+-------
+
+The JunkHAL currently only supports AVR processors. To build JunkHAL for all supported processors:
+```
+$ cd <junk_root>/hal/avr
+$ make libs
+```
+Use `make help` to see all build options.

--- a/hal/avr/Makefile
+++ b/hal/avr/Makefile
@@ -9,8 +9,11 @@
 CC = gcc
 CXX = g++
 AVR_CC = avr-gcc
+AVR_CXX = avr-g++
 AVR_AR = avr-ar
+AVR_OBJCOPY = avr-objcopy
 AVR_OBJDUMP = avr-objdump
+AVR_PROG = avrdude
 
 # Shell Commands #
 CP    = cp -fr
@@ -44,6 +47,13 @@ AVR_UT_CFLAGS = -Wall -Werror -ggdb
 AVR_UT_CPPFLAGS = -Wall -Werror -ggdb
 AVR_UT_LDFLAGS =
 AVR_UT_LDLIBS =
+AVR_FT_CFLAGS = -Wall -Werror
+AVR_FT_CPPFLAGS = -Wall -Werror
+AVR_FT_LDFLAGS =
+AVR_FT_LDLIBS =
+AVR_FT_OBJCOPYFLAGS = -j .text -j .data -O ihex
+AVR_FT_PROGFLAGS = -c avrispmkII -P usb
+
 
 ### Application Configuration ###
 
@@ -56,21 +66,48 @@ UNITY_INCLUDES = $(THIRDPARTY_DIR)/unity/src
 
 ### Global Goals ###
 
-ALL_LIB_TARGETS = $(LIB_ATTINY85_TARGET)
-ALL_UT_TARGETS = $(PIN_ATTINYx5_TARGET)
-
 .PHONY: all
 all: build
 
-.SECONDEXPANSION:
-.PHONY: build
-build: $$(addsuffix _build,$$(ALL_LIB_TARGETS) $$(ALL_UT_TARGETS))
-
-.PHONY: test
-test: $$(addsuffix _run,$$(ALL_UT_TARGETS))
-
-.PHONY: clean
-clean: $$(addsuffix _clean,$$(ALL_LIB_TARGETS) $$(ALL_UT_TARGETS))
+.PHONY: help
+help:
+	@echo "##################"
+	@echo "#  JunkHAL: AVR  #"
+	@echo "##################"
+	@echo ""
+	@echo "General options:"
+	@echo "    all        Build all targets [default]"
+	@echo "    build      Build all targets"
+	@echo "    libs       Build all library targets"
+	@echo "    uts        Build all unit test targets"
+	@echo "    fts        Build all functional test targets"
+	@echo "    test       Build and run all unit test targets"
+	@echo "    clean      Clean all targets"
+	@echo ""
+	@echo "Library targets:"
+	@echo "    lib_<proc>_[build|clean]                Builds the JunkHAL into a static library for"
+	@echo "                                            the given AVR processor."
+	@echo ""
+	@echo "Available library targets:"
+	@echo $(foreach target,$(ALL_LIBS), "    $(target)_build\n    $(target)_clean\n")
+	@echo ""
+	@echo "Unit test targets:"
+	@echo "    ut_<family>_<unit>_[build|run|clean]    Builds/runs the unit test for the given"
+	@echo "                                            unit/driver of the specified family of AVR"
+	@echo "                                            processors."
+	@echo ""
+	@echo "Available unit test targets:"
+	@echo $(foreach target,$(ALL_UTS), "    $(target)_build\n    $(target)_run\n    $(target)_clean\n")
+	@echo ""
+	@echo "Functional test targets:"
+	@echo "    ft_<family>_<unit>_[build|run|clean]    Builds/flashes the functional test for the"
+	@echo "                                            given unit/driver with the specified family"
+	@echo "                                            of AVR processors. Running means flashing"
+	@echo "                                            the application via an AVR-ISP mkII."
+	@echo ""
+	@echo "Available functional test targets:"
+	@echo $(foreach target,$(ALL_FTS), "    $(target)_build\n    $(target)_run\n    $(target)_clean\n")
+	@echo ""
 
 # Output Directory #
 $(AVR_OUTPUT_DIR):
@@ -100,18 +137,64 @@ $(eval $(call LIB_tmpl,$(LIB_ATTINY85_TARGET),$(LIB_ATTINY85_FAMILY),$(LIB_ATTIN
 include make/unittest.mk
 
 # ATTinyx5 Pin Driver #
-PIN_ATTINYx5_TARGET := test_pin_attinyx5
-PIN_ATTINYx5_FAMILY := attinyx5
-PIN_ATTINYx5_SOURCES := $(AVR_TESTS_DIR)/attinyx5/test_pin_attinyx5.cpp \
+UT_PIN_ATTINYx5_TARGET := pin
+UT_PIN_ATTINYx5_FAMILY := attinyx5
+UT_PIN_ATTINYx5_SOURCES := $(AVR_TESTS_DIR)/attinyx5/test_pin_attinyx5.cpp \
                         $(AVR_SOURCE_DIR)/attinyx5/pin.cpp \
                         $(AVR_MOCKS_DIR)/attinyx5/io.c \
                         $(UNITY_SOURCES)
-PIN_ATTINYx5_INCLUDES := $(AVR_MOCKS_DIR)/attinyx5/include \
+UT_PIN_ATTINYx5_INCLUDES := $(AVR_MOCKS_DIR)/attinyx5/include \
                          $(UTIL_INCLUDE_DIR) \
                          $(UNITY_INCLUDES)
-PIN_ATTINYx5_CFLAGS := -D__AVR_ATtiny85__
-PIN_ATTINYx5_CPPFLAGS := -D__AVR_ATtiny85__
-PIN_ATTINYx5_LDFLAGS :=
-PIN_ATTINYx5_LDLIBS :=
+UT_PIN_ATTINYx5_CFLAGS := -D__AVR_ATtiny85__
+UT_PIN_ATTINYx5_CPPFLAGS := -D__AVR_ATtiny85__
+UT_PIN_ATTINYx5_LDFLAGS :=
+UT_PIN_ATTINYx5_LDLIBS :=
 
-$(eval $(call UT_tmpl,$(PIN_ATTINYx5_TARGET),$(PIN_ATTINYx5_FAMILY),$(PIN_ATTINYx5_SOURCES),$(PIN_ATTINYx5_INCLUDES),$(PIN_ATTINYx5_CFLAGS),$(PIN_ATTINYx5_CPPFLAGS),$(PIN_ATTINYx5_LDFLAGS),$(PIN_ATTINYx5_LDLIBS)))
+$(eval $(call UT_tmpl,$(UT_PIN_ATTINYx5_TARGET),$(UT_PIN_ATTINYx5_FAMILY),$(UT_PIN_ATTINYx5_SOURCES),$(UT_PIN_ATTINYx5_INCLUDES),$(UT_PIN_ATTINYx5_CFLAGS),$(UT_PIN_ATTINYx5_CPPFLAGS),$(UT_PIN_ATTINYx5_LDFLAGS),$(UT_PIN_ATTINYx5_LDLIBS)))
+
+### Functional Tests ###
+
+include make/functest.mk
+
+# ATTiny85 Pin Driver #
+FT_PIN_ATTINY85_TARGET := pin
+FT_PIN_ATTINY85_FAMILY := attinyx5
+FT_PIN_ATTINY85_MCU := attiny85
+FT_PIN_ATTINY85_SOURCES := $(AVR_TESTS_DIR)/attinyx5/functest_pin_attinyx5.cpp \
+                        $(AVR_SOURCE_DIR)/attinyx5/pin.cpp \
+                        $(AVR_SOURCE_DIR)/attinyx5/delay_instr.S
+FT_PIN_ATTINY85_INCLUDES := $(AVR_INCLUDE_DIR) \
+                         $(UTIL_INCLUDE_DIR)
+FT_PIN_ATTINY85_CFLAGS := -g -Os -mmcu=$(FT_PIN_ATTINY85_MCU)
+FT_PIN_ATTINY85_CPPFLAGS := -g -Os -mmcu=$(FT_PIN_ATTINY85_MCU)
+FT_PIN_ATTINY85_LDFLAGS := -g -mmcu=$(FT_PIN_ATTINY85_MCU) -Wl,-T,$(AVR_LINKER_DIR)/attiny85.x
+FT_PIN_ATTINY85_LDLIBS :=
+FT_PIN_ATTINY85_OBJCOPY_FLAGS :=
+FT_PIN_ATTINY85_LFUSE := 0xE2
+FT_PIN_ATTINY85_HFUSE := 0xDF
+FT_PIN_ATTINY85_EFUSE := 0xFF
+FT_PIN_ATTINY85_PROG_FLAGS := -p t85 -U lfuse:w:$(FT_PIN_ATTINY85_LFUSE):m -U hfuse:w:$(FT_PIN_ATTINY85_HFUSE):m -U efuse:w:$(FT_PIN_ATTINY85_EFUSE):m
+
+$(eval $(call FT_tmpl,$(FT_PIN_ATTINY85_TARGET),$(FT_PIN_ATTINY85_FAMILY),$(FT_PIN_ATTINY85_MCU),$(FT_PIN_ATTINY85_SOURCES),$(FT_PIN_ATTINY85_INCLUDES),$(FT_PIN_ATTINY85_CFLAGS),$(FT_PIN_ATTINY85_CPPFLAGS),$(FT_PIN_ATTINY85_LDFLAGS),$(FT_PIN_ATTINY85_LDLIBS),$(FT_PIN_ATTINY85_OBJCOPY_FLAGS),$(FT_PIN_ATTINY85_PROG_FLAGS)))
+
+
+## These must be at the bottom of the file ##
+
+.PHONY: build
+build: $(addsuffix _build,$(ALL_LIBS) $(ALL_UTS) $(ALL_FTS))
+
+.PHONY: libs
+libs: $(addsuffix _build,$(ALL_LIBS))
+
+.PHONY: uts
+uts: $(addsuffix _build,$(ALL_UTS))
+
+.PHONY: fts
+fts: $(addsuffix _build,$(ALL_FTS))
+
+.PHONY: test
+test: $(addsuffix _run,$(ALL_UTS))
+
+.PHONY: clean
+clean: $(addsuffix _clean,$(ALL_LIBS) $(ALL_UTS) $(ALL_FTS))

--- a/hal/avr/include/junk/hal/attinyx5/pin.h
+++ b/hal/avr/include/junk/hal/attinyx5/pin.h
@@ -20,20 +20,25 @@ class Pin : public IPin {
 public:
     typedef uint8_t PinNum;
 
+    /**
+     * @brief Pull-up/Pull-down options.
+     *
+     * The ATTinyx5 family only provides for pull-up or no pull options.
+     */
     enum PuPd
     {
-        PUPD_NONE     = 0U,
-        PUPD_PULLDOWN = 1U,
-        PUPD_PULLUP   = 2U
+        PUPD_NONE     = 0U, ///< No pull-up on the pin.
+        PUPD_PULLUP   = 1U  ///< Set a pull-up on the pin.
     };
 
     /* Note: There is only one pin bank in the ATTinyx5 family: bank B */
-    Pin( const PinNum num, const bool asserted_high );
+    Pin( const PinNum num, const bool asserted_high = true );
     virtual ~Pin() {};
 
     void setPuPd( const PuPd pupd );
     virtual void setDirection( const Direction dir );
     virtual bool read() const;
+    virtual void set(bool asserted);
     virtual void assert();
     virtual void deassert();
     virtual void toggle();

--- a/hal/avr/linker/attiny85.x
+++ b/hal/avr/linker/attiny85.x
@@ -1,0 +1,228 @@
+/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-avr","elf32-avr","elf32-avr")
+OUTPUT_ARCH(avr:25)
+MEMORY
+{
+  text      (rx)   : ORIGIN = 0, LENGTH = 4K
+  data      (rw!x) : ORIGIN = 0x800060, LENGTH = 0x200
+  eeprom    (rw!x) : ORIGIN = 0x810000, LENGTH = 64K
+  fuse      (rw!x) : ORIGIN = 0x820000, LENGTH = 1K
+  lock      (rw!x) : ORIGIN = 0x830000, LENGTH = 1K
+  signature (rw!x) : ORIGIN = 0x840000, LENGTH = 1K
+}
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  .hash          : { *(.hash)    }
+  .dynsym        : { *(.dynsym)    }
+  .dynstr        : { *(.dynstr)    }
+  .gnu.version   : { *(.gnu.version)  }
+  .gnu.version_d   : { *(.gnu.version_d)  }
+  .gnu.version_r   : { *(.gnu.version_r)  }
+  .rel.init      : { *(.rel.init)    }
+  .rela.init     : { *(.rela.init)  }
+  .rel.text      :
+    {
+      *(.rel.text)
+      *(.rel.text.*)
+      *(.rel.gnu.linkonce.t*)
+    }
+  .rela.text     :
+    {
+      *(.rela.text)
+      *(.rela.text.*)
+      *(.rela.gnu.linkonce.t*)
+    }
+  .rel.fini      : { *(.rel.fini)    }
+  .rela.fini     : { *(.rela.fini)  }
+  .rel.rodata    :
+    {
+      *(.rel.rodata)
+      *(.rel.rodata.*)
+      *(.rel.gnu.linkonce.r*)
+    }
+  .rela.rodata   :
+    {
+      *(.rela.rodata)
+      *(.rela.rodata.*)
+      *(.rela.gnu.linkonce.r*)
+    }
+  .rel.data      :
+    {
+      *(.rel.data)
+      *(.rel.data.*)
+      *(.rel.gnu.linkonce.d*)
+    }
+  .rela.data     :
+    {
+      *(.rela.data)
+      *(.rela.data.*)
+      *(.rela.gnu.linkonce.d*)
+    }
+  .rel.ctors     : { *(.rel.ctors)  }
+  .rela.ctors    : { *(.rela.ctors)  }
+  .rel.dtors     : { *(.rel.dtors)  }
+  .rela.dtors    : { *(.rela.dtors)  }
+  .rel.got       : { *(.rel.got)    }
+  .rela.got      : { *(.rela.got)    }
+  .rel.bss       : { *(.rel.bss)    }
+  .rela.bss      : { *(.rela.bss)    }
+  .rel.plt       : { *(.rel.plt)    }
+  .rela.plt      : { *(.rela.plt)    }
+  /* Internal text space or external memory.  */
+  .text   :
+  {
+    *(.vectors)
+    KEEP(*(.vectors))
+    /* For data that needs to reside in the lower 64k of progmem.  */
+    *(.progmem.gcc*)
+    *(.progmem*)
+    . = ALIGN(2);
+     __trampolines_start = . ;
+    /* The jump trampolines for the 16-bit limited relocs will reside here.  */
+    *(.trampolines)
+    *(.trampolines*)
+     __trampolines_end = . ;
+    /* For future tablejump instruction arrays for 3 byte pc devices.
+       We don't relax jump/call instructions within these sections.  */
+    *(.jumptables)
+    *(.jumptables*)
+    /* For code that needs to reside in the lower 128k progmem.  */
+    *(.lowtext)
+    *(.lowtext*)
+     __ctors_start = . ;
+     *(.ctors)
+     __ctors_end = . ;
+     __dtors_start = . ;
+     *(.dtors)
+     __dtors_end = . ;
+    KEEP(SORT(*)(.ctors))
+    KEEP(SORT(*)(.dtors))
+    /* From this point on, we don't bother about wether the insns are
+       below or above the 16 bits boundary.  */
+    *(.init0)  /* Start here after reset.  */
+    KEEP (*(.init0))
+    *(.init1)
+    KEEP (*(.init1))
+    *(.init2)  /* Clear __zero_reg__, set up stack pointer.  */
+    KEEP (*(.init2))
+    *(.init3)
+    KEEP (*(.init3))
+    *(.init4)  /* Initialize data and BSS.  */
+    KEEP (*(.init4))
+    *(.init5)
+    KEEP (*(.init5))
+    *(.init6)  /* C++ constructors.  */
+    KEEP (*(.init6))
+    *(.init7)
+    KEEP (*(.init7))
+    *(.init8)
+    KEEP (*(.init8))
+    *(.init9)  /* Call main().  */
+    KEEP (*(.init9))
+    *(.text)
+    . = ALIGN(2);
+    *(.text.*)
+    . = ALIGN(2);
+    *(.fini9)  /* _exit() starts here.  */
+    KEEP (*(.fini9))
+    *(.fini8)
+    KEEP (*(.fini8))
+    *(.fini7)
+    KEEP (*(.fini7))
+    *(.fini6)  /* C++ destructors.  */
+    KEEP (*(.fini6))
+    *(.fini5)
+    KEEP (*(.fini5))
+    *(.fini4)
+    KEEP (*(.fini4))
+    *(.fini3)
+    KEEP (*(.fini3))
+    *(.fini2)
+    KEEP (*(.fini2))
+    *(.fini1)
+    KEEP (*(.fini1))
+    *(.fini0)  /* Infinite loop after program termination.  */
+    KEEP (*(.fini0))
+     _etext = . ;
+  }  > text
+  .data    : AT (ADDR (.text) + SIZEOF (.text))
+  {
+     PROVIDE (__data_start = .) ;
+    *(.data)
+    *(.data*)
+    *(.rodata)  /* We need to include .rodata here if gcc is used */
+    *(.rodata*) /* with -fdata-sections.  */
+    *(.gnu.linkonce.d*)
+    . = ALIGN(2);
+     _edata = . ;
+     PROVIDE (__data_end = .) ;
+  }  > data
+  .bss   : AT (ADDR (.bss))
+  {
+     PROVIDE (__bss_start = .) ;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+     PROVIDE (__bss_end = .) ;
+  }  > data
+   __data_load_start = LOADADDR(.data);
+   __data_load_end = __data_load_start + SIZEOF(.data);
+  /* Global data not cleared after reset.  */
+  .noinit  :
+  {
+     PROVIDE (__noinit_start = .) ;
+    *(.noinit*)
+     PROVIDE (__noinit_end = .) ;
+     _end = . ;
+     PROVIDE (__heap_start = .) ;
+  }  > data
+  .eeprom  :
+  {
+    *(.eeprom*)
+     __eeprom_end = . ;
+  }  > eeprom
+  .fuse  :
+  {
+    KEEP(*(.fuse))
+    KEEP(*(.lfuse))
+    KEEP(*(.hfuse))
+    KEEP(*(.efuse))
+  }  > fuse
+  .lock  :
+  {
+    KEEP(*(.lock*))
+  }  > lock
+  .signature  :
+  {
+    KEEP(*(.signature*))
+  }  > signature
+  /* Stabs debugging sections.  */
+  .stab 0 : { *(.stab) }
+  .stabstr 0 : { *(.stabstr) }
+  .stab.excl 0 : { *(.stab.excl) }
+  .stab.exclstr 0 : { *(.stab.exclstr) }
+  .stab.index 0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment 0 : { *(.comment) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info) *(.gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+}

--- a/hal/avr/make/functest.mk
+++ b/hal/avr/make/functest.mk
@@ -1,0 +1,146 @@
+##
+# Func Test Template
+#
+# Params:
+# 1 - Target name. Used to uniquely identify all variables.
+# 2 - Family. Used to uniquely identify path to source files.
+# 3 - MCU
+# 4 - Sources
+# 5 - Include paths
+# 6 - C flags
+# 7 - CPP flags
+# 8 - Linker flags
+# 9 - Linker libs
+# 10 - Objcpy flags
+# 11 - Programming flags
+#
+#
+# Output Targets:
+# FT_$(2)_$(1)_build - Build the functest target
+# FT_$(2)_$(1)_flash - Flash the functest target
+# FT_$(2)_$(1)_clean - Clean all build and output files
+#
+define FT_tmpl
+
+### Setup ###
+
+# Directories #
+FT_$(2)_$(1)_BUILD_DIR = $$(AVR_BUILD_DIR)/ft/$(2)/$(1)
+FT_$(2)_$(1)_OUTPUT_DIR = $$(AVR_OUTPUT_DIR)/ft/$(2)/$(1)
+
+# Build Flags #
+FT_$(2)_$(1)_CFLAGS = $$(AVR_FT_CFLAGS) $(6)
+FT_$(2)_$(1)_CPPFLAGS = $$(AVR_FT_CPPFLAGS) $(7)
+FT_$(2)_$(1)_LDFLAGS = $$(AVR_FT_LDFLAGS) -Wl,-Map,$$(FT_$(2)_$(1)_MAP) $(8)
+FT_$(2)_$(1)_LDLIBS = $$(AVR_FT_LDLIBS) $(9)
+FT_$(2)_$(1)_OBJCOPY_FLAGS = $$(AVR_FT_OBJCOPYFLAGS) $(10)
+FT_$(2)_$(1)_PROG_FLAGS = $$(AVR_FT_PROGFLAGS) $(11)
+
+# Source Files #
+FT_$(2)_$(1)_SOURCES = $(4) $$(AVR_COMMON_DIR)/stdcpp.cpp
+FT_$(2)_$(1)_OBJECTS = $$(addprefix $$(FT_$(2)_$(1)_BUILD_DIR)/,$$(notdir $$(addsuffix .o,$$(basename $$(FT_$(2)_$(1)_SOURCES)))))
+
+# Include Paths #
+FT_$(2)_$(1)_INCLUDES = $$(COMMON_INCLUDE_DIR) $$(AVR_INCLUDE_DIR) $(5)
+FT_$(2)_$(1)_INCLUDE_FLAGS = $$(addprefix -I,$$(FT_$(2)_$(1)_INCLUDES))
+
+# Output Files #
+FT_$(2)_$(1)_ELF = $$(FT_$(2)_$(1)_BUILD_DIR)/$(1).elf
+FT_$(2)_$(1)_HEX = $$(FT_$(2)_$(1)_OUTPUT_DIR)/$(1).hex
+FT_$(2)_$(1)_MAP = $$(FT_$(2)_$(1)_OUTPUT_DIR)/$(1).map
+
+# Set VPATH #
+VPATH += $(THIRDPARTY_DIR)/unity/src
+
+### Targets ###
+
+ALL_FTS += ft_$(2)_$(1)
+
+# Build Rule #
+.PHONY: ft_$(2)_$(1)_build
+ft_$(2)_$(1)_build: $$(FT_$(2)_$(1)_HEX)
+
+# Flash Rule #
+.PHONY: ft_$(2)_$(1)_run
+ft_$(2)_$(1)_run: FT_$(2)_$(1)_build
+	$$(AVR_PROG) $$(FT_$(2)_$(1)_PROG_FLAGS) -v -U flash:w:$$(FT_$(2)_$(1)_HEX)
+
+# Clean Rule #
+.PHONY: ft_$(2)_$(1)_clean
+ft_$(2)_$(1)_clean:
+	$$(RMDIR) $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(RMDIR) $$(FT_$(2)_$(1)_OUTPUT_DIR)
+
+### Build Recipes ###
+
+# Build Dependencies #
+-include $$(FT_$(2)_$(1)_OBJECTS:.o=.d)
+
+# Build Directory #
+$$(FT_$(2)_$(1)_BUILD_DIR):
+	@$$(MKDIR) $$@
+
+# Output Directory #
+$$(FT_$(2)_$(1)_OUTPUT_DIR):
+	@$$(MKDIR) $$@
+
+# Common Sources #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# Common AVR Sources #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# Family Specific Sources #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.S | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# Family Specific Mocks #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# Family Specific Stubs #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CPPFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# Family Specific Tests #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CPPFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# General Sources #
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: %.c | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(FT_$(2)_$(1)_CFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+$$(FT_$(2)_$(1)_BUILD_DIR)/%.o: %.cpp | $$(FT_$(2)_$(1)_BUILD_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_CPPFLAGS) $$(FT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+
+# Elf Target #
+$$(FT_$(2)_$(1)_ELF): $$(FT_$(2)_$(1)_OBJECTS) | $$(FT_$(2)_$(1)_OUTPUT_DIR)
+	$$(AVR_CXX) $$(FT_$(2)_$(1)_LDFLAGS) $$^ $$(FT_$(2)_$(1)_LDLIBS) -o $$@
+
+# Hex Target #
+$$(FT_$(2)_$(1)_HEX): $$(FT_$(2)_$(1)_ELF)
+	$$(AVR_OBJCOPY) $$(FT_$(2)_$(1)_OBJCOPY_FLAGS) $$(FT_$(2)_$(1)_ELF) $$@
+endef

--- a/hal/avr/make/library.mk
+++ b/hal/avr/make/library.mk
@@ -20,104 +20,106 @@ define LIB_tmpl
 ### Setup ###
 
 # Directories #
-$(1)_BUILD_DIR = $$(AVR_BUILD_DIR)/$(1)
-$(1)_OUTPUT_DIR = $$(AVR_OUTPUT_DIR)/$(1)
+LIB_$(1)_BUILD_DIR = $$(AVR_BUILD_DIR)/$(1)
+LIB_$(1)_OUTPUT_DIR = $$(AVR_OUTPUT_DIR)/$(1)
 
 # Build Flags #
-$(1)_CFLAGS = $$(AVR_LIB_CFLAGS) $(5)
-$(1)_CPPFLAGS = $$(AVR_LIB_CPPFLAGS) $(6)
-$(1)_ARFLAGS = $$(AVR_LIB_ARFLAGS) $(7)
-$(1)_OBJDUMPFLAGS = $$(AVR_LIB_OBJDUMPFLAGS) $(8)
+LIB_$(1)_CFLAGS = $$(AVR_LIB_CFLAGS) $(5)
+LIB_$(1)_CPPFLAGS = $$(AVR_LIB_CPPFLAGS) $(6)
+LIB_$(1)_ARFLAGS = $$(AVR_LIB_ARFLAGS) $(7)
+LIB_$(1)_OBJDUMPFLAGS = $$(AVR_LIB_OBJDUMPFLAGS) $(8)
 
 # Source Files #
-$(1)_SOURCES = $(3)
-$(1)_OBJECTS = $$(addprefix $$($(1)_BUILD_DIR)/,$$(notdir $$(addsuffix .o,$$(basename $$($(1)_SOURCES)))))
+LIB_$(1)_SOURCES = $(3)
+LIB_$(1)_OBJECTS = $$(addprefix $$(LIB_$(1)_BUILD_DIR)/,$$(notdir $$(addsuffix .o,$$(basename $$(LIB_$(1)_SOURCES)))))
 
 # Include Paths #
-$(1)_INCLUDES = $$(COMMON_INCLUDE_DIR) $$(AVR_INCLUDE_DIR) $(4)
-$(1)_INCLUDE_FLAGS = $$(addprefix -I,$$($(1)_INCLUDES))
+LIB_$(1)_INCLUDES = $$(COMMON_INCLUDE_DIR) $$(AVR_INCLUDE_DIR) $(4)
+LIB_$(1)_INCLUDE_FLAGS = $$(addprefix -I,$$(LIB_$(1)_INCLUDES))
 
 # Output Files #
-$(1)_LST = $$($(1)_OUTPUT_DIR)/junk-$(1).lst
-$(1)_A = $$($(1)_OUTPUT_DIR)/junk-$(1).a
+LIB_$(1)_LST = $$(LIB_$(1)_OUTPUT_DIR)/junkhal-$(1).lst
+LIB_$(1)_A = $$(LIB_$(1)_OUTPUT_DIR)/junkhal-$(1).a
 
 ### Targets ###
 
+ALL_LIBS += lib_$(1)
+
 # Build Rule #
-.PHONY: $(1)_build
-$(1)_build: $$($(1)_A)
+.PHONY: lib_$(1)_build
+lib_$(1)_build: $$(LIB_$(1)_A)
 
 # Clean Rule #
-.PHONY: $(1)_clean
-$(1)_clean:
-	$$(RMDIR) $$($(1)_BUILD_DIR)
-	$$(RMDIR) $$($(1)_OUTPUT_DIR)
+.PHONY: lib_$(1)_clean
+lib_$(1)_clean:
+	$$(RMDIR) $$(LIB_$(1)_BUILD_DIR)
+	$$(RMDIR) $$(LIB_$(1)_OUTPUT_DIR)
 
 ### Build Recipes ###
 
 # Build Dependencies #
--include $$($(1)_OBJECTS:.o=.d)
+-include $$(LIB_$(1)_OBJECTS:.o=.d)
 
 # Build Directory #
-$$($(1)_BUILD_DIR):
+$$(LIB_$(1)_BUILD_DIR):
 	@$$(MKDIR) $$@
 
 # Output Directory #
-$$($(1)_OUTPUT_DIR):
+$$(LIB_$(1)_OUTPUT_DIR):
 	@$$(MKDIR) $$@
 
 # Common Sources #
-$$($(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Common AVR Sources #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Sources #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Mocks #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Stubs #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CPPFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CPPFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Tests #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CPPFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CPPFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # General Sources #
-$$($(1)_BUILD_DIR)/%.o: %.c | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: %.c | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: %.cpp | $$($(1)_BUILD_DIR)
-	$$(AVR_CC) $$($(1)_CPPFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(LIB_$(1)_BUILD_DIR)/%.o: %.cpp | $$(LIB_$(1)_BUILD_DIR)
+	$$(AVR_CC) $$(LIB_$(1)_CPPFLAGS) $$(LIB_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Link Target #
-$$($(1)_A): $$($(1)_OBJECTS) | $$($(1)_OUTPUT_DIR)
-	$$(AVR_AR) $$($(1)_ARFLAGS) -rc $$@ $$^
-	$$(AVR_OBJDUMP) $$($(1)_OBJDUMPFLAGS) -h -S $$@ > $$($(1)_LST)
+$$(LIB_$(1)_A): $$(LIB_$(1)_OBJECTS) | $$(LIB_$(1)_OUTPUT_DIR)
+	$$(AVR_AR) $$(LIB_$(1)_ARFLAGS) -rc $$@ $$^
+	$$(AVR_OBJDUMP) $$(LIB_$(1)_OBJDUMPFLAGS) -h -S $$@ > $$(LIB_$(1)_LST)
 
 endef

--- a/hal/avr/make/unittest.mk
+++ b/hal/avr/make/unittest.mk
@@ -12,119 +12,121 @@
 # 8 - Linker libs
 #
 # Output Targets:
-# $(1)_build - Build the test target
-# $(1)_run - Execute the test target
-# $(1)_clean - Clean all build and output files
+# UT_$(2)_$(1)_build - Build the test target
+# UT_$(2)_$(1)_run - Execute the test target
+# UT_$(2)_$(1)_clean - Clean all build and output files
 #
 define UT_tmpl
 
 ### Setup ###
 
 # Directories #
-$(1)_BUILD_DIR = $$(AVR_BUILD_DIR)/$(1)
-$(1)_OUTPUT_DIR = $$(AVR_OUTPUT_DIR)/$(1)
+UT_$(2)_$(1)_BUILD_DIR = $$(AVR_BUILD_DIR)/ut/$(2)/$(1)
+UT_$(2)_$(1)_OUTPUT_DIR = $$(AVR_OUTPUT_DIR)/ut/$(2)/$(1)
 
 # Build Flags #
-$(1)_CFLAGS = $$(AVR_CFLAGS) $(5)
-$(1)_CPPFLAGS = $$(AVR_CPPFLAGS) $(6)
-$(1)_LDFLAGS = $$(AVR_LDFLAGS) $(7)
-$(1)_LDLIBS = $$(AVR_LDLIBS) $(8)
+UT_$(2)_$(1)_CFLAGS = $$(AVR_CFLAGS) $(5)
+UT_$(2)_$(1)_CPPFLAGS = $$(AVR_CPPFLAGS) $(6)
+UT_$(2)_$(1)_LDFLAGS = $$(AVR_LDFLAGS) $(7)
+UT_$(2)_$(1)_LDLIBS = $$(AVR_LDLIBS) $(8)
 
 # Source Files #
-$(1)_SOURCES = $(3)
-$(1)_OBJECTS = $$(addprefix $$($(1)_BUILD_DIR)/,$$(notdir $$(addsuffix .o,$$(basename $$($(1)_SOURCES)))))
+UT_$(2)_$(1)_SOURCES = $(3)
+UT_$(2)_$(1)_OBJECTS = $$(addprefix $$(UT_$(2)_$(1)_BUILD_DIR)/,$$(notdir $$(addsuffix .o,$$(basename $$(UT_$(2)_$(1)_SOURCES)))))
 
 # Include Paths #
-$(1)_INCLUDES = $$(COMMON_INCLUDE_DIR) $$(AVR_INCLUDE_DIR) $(4)
-$(1)_INCLUDE_FLAGS = $$(addprefix -I,$$($(1)_INCLUDES))
+UT_$(2)_$(1)_INCLUDES = $$(COMMON_INCLUDE_DIR) $$(AVR_INCLUDE_DIR) $(4)
+UT_$(2)_$(1)_INCLUDE_FLAGS = $$(addprefix -I,$$(UT_$(2)_$(1)_INCLUDES))
 
 # Output Files #
-$(1)_EXE = $$($(1)_OUTPUT_DIR)/$(1)
+UT_$(2)_$(1)_EXE = $$(UT_$(2)_$(1)_OUTPUT_DIR)/$(1)
 
 # Set VPATH #
 VPATH += $(THIRDPARTY_DIR)/unity/src
 
 ### Targets ###
 
+ALL_UTS += ut_$(2)_$(1)
+
 # Build Rule #
-.PHONY: $(1)_build
-$(1)_build: $$($(1)_EXE)
+.PHONY: ut_$(2)_$(1)_build
+ut_$(2)_$(1)_build: $$(UT_$(2)_$(1)_EXE)
 
 # Run Rule #
-.PHONY: $(1)_run
-$(1)_run: $(1)_build
-	@$$($(1)_EXE)
+.PHONY: ut_$(2)_$(1)_run
+ut_$(2)_$(1)_run: ut_$(2)_$(1)_build
+	@$$(UT_$(2)_$(1)_EXE)
 
 # Clean Rule #
-.PHONY: $(1)_clean
-$(1)_clean:
-	$$(RMDIR) $$($(1)_BUILD_DIR)
-	$$(RMDIR) $$($(1)_OUTPUT_DIR)
+.PHONY: ut_$(2)_$(1)_clean
+ut_$(2)_$(1)_clean:
+	$$(RMDIR) $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(RMDIR) $$(UT_$(2)_$(1)_OUTPUT_DIR)
 
 ### Build Recipes ###
 
 # Build Dependencies #
--include $$($(1)_OBJECTS:.o=.d)
+-include $$(UT_$(2)_$(1)_OBJECTS:.o=.d)
 
 # Build Directory #
-$$($(1)_BUILD_DIR):
+$$(UT_$(2)_$(1)_BUILD_DIR):
 	@$$(MKDIR) $$@
 
 # Output Directory #
-$$($(1)_OUTPUT_DIR):
+$$(UT_$(2)_$(1)_OUTPUT_DIR):
 	@$$(MKDIR) $$@
 
 # Common Sources #
-$$($(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(COMMON_SOURCE_DIR)/%.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Common AVR Sources #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_COMMON_DIR)/%.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Sources #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_SOURCE_DIR)/$(2)/%.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Mocks #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_MOCKS_DIR)/$(2)/%.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Stubs #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CPPFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_STUBS_DIR)/$(2)/%.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CPPFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Family Specific Tests #
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CPPFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: $$(AVR_TESTS_DIR)/$(2)/%.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CPPFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # General Sources #
-$$($(1)_BUILD_DIR)/%.o: %.c | $$($(1)_BUILD_DIR)
-	$$(CC) $$($(1)_CFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: %.c | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CC) $$(UT_$(2)_$(1)_CFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
-$$($(1)_BUILD_DIR)/%.o: %.cpp | $$($(1)_BUILD_DIR)
-	$$(CXX) $$($(1)_CPPFLAGS) $$($(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
+$$(UT_$(2)_$(1)_BUILD_DIR)/%.o: %.cpp | $$(UT_$(2)_$(1)_BUILD_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_CPPFLAGS) $$(UT_$(2)_$(1)_INCLUDE_FLAGS) -MD -c $$< -o $$@
 
 # Link Target #
-$$($(1)_EXE): $$($(1)_OBJECTS) | $$($(1)_OUTPUT_DIR)
-	$$(CXX) $$($(1)_LDFLAGS) $$^ $$($(1)_LDLIBS) -o $$@
+$$(UT_$(2)_$(1)_EXE): $$(UT_$(2)_$(1)_OBJECTS) | $$(UT_$(2)_$(1)_OUTPUT_DIR)
+	$$(CXX) $$(UT_$(2)_$(1)_LDFLAGS) $$^ $$(UT_$(2)_$(1)_LDLIBS) -o $$@
 
 endef

--- a/hal/avr/src/attinyx5/pin.cpp
+++ b/hal/avr/src/attinyx5/pin.cpp
@@ -91,6 +91,15 @@ bool Pin::read() const
     return (m_asserted_high == (bool)(PINB & (1<<(m_num))));
 }
 
+void Pin::set(bool asserted)
+{
+    if (asserted) {
+        assert();
+    } else {
+        deassert();
+    }
+}
+
 /**
  * @brief Assert the pin (output only).
  */

--- a/hal/avr/src/attinyx5/pin.cpp
+++ b/hal/avr/src/attinyx5/pin.cpp
@@ -91,6 +91,12 @@ bool Pin::read() const
     return (m_asserted_high == (bool)(PINB & (1<<(m_num))));
 }
 
+/**
+ * @brief Set the pin to the given state (output only).
+ *
+ * @param[in]  asserted
+ *             The new state to set the pin to. `true` is asserted, `false` is deasserted.
+ */
 void Pin::set(bool asserted)
 {
     if (asserted) {

--- a/hal/avr/src/common/stdcpp.cpp
+++ b/hal/avr/src/common/stdcpp.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file      stdcpp.cpp
+ * @brief     This file contains some missing C++ standard library components.
+ * @author    Liam Bucci <liam.bucci@gmail.com>
+ * @date      2018-02-15
+ * @copyright Copyright (c) 2017 Liam Bucci. See included LICENSE file.
+ */
+
+#include <stdlib.h>
+
+void * operator new(size_t n)
+{
+  void * const p = malloc(n);
+  // handle p == 0
+  return p;
+}
+
+void operator delete(void * p)
+{
+  free(p);
+}

--- a/hal/avr/tests/attinyx5/functest_pin_attinyx5.cpp
+++ b/hal/avr/tests/attinyx5/functest_pin_attinyx5.cpp
@@ -1,0 +1,71 @@
+/**
+ * @file      test_pin_attinyx5.c
+ * @brief     This file contains tests for ATtinyx5 series pin driver.
+ * @author    Liam Bucci <liam.bucci@gmail.com>
+ * @date      2017-09-22
+ * @copyright Copyright (c) 2017 Liam Bucci. See included LICENSE file.
+ */
+
+#include <stdint.h>
+
+#include "junk/hal/attinyx5/pin.h"
+#include "junk/hal/attinyx5/delay_instr.h"
+
+using namespace junk::hal;
+
+void functest();
+
+int main(int argc, char** argv)
+{
+    functest();
+
+    return 0;
+}
+
+/**
+ * @brief The ATTinyx5 family Pin driver functional test.
+ *
+ * ## Hardware Setup
+ *
+ * - Use the MikroElektronica EasyAVRv7.
+ * - Put an ATTinyx5 chip in one of the DIP slots.
+ * - Connect an AVR-ISP or similar programmer.
+ * - Ensure PORTB LEDs are ON (SW10).
+ * - Button press levels (SW1) should be VCC.
+ * - Add a pull-down to PB1.
+ *
+ * ## Expected Results
+ *
+ * - Initially, all LEDs except PB4 should be off.
+ * - While PB1 button is pressed:
+ *   - PB0 will turn on.
+ *   - PB2 will be toggling, but it is too fast to see.
+ *   - PB4 will turn off.
+ * - When PB1 is released:
+ *   - PB0 will turn off.
+ *   - PB2 will be in an indeterminate state (could be off or on).
+ *   - PB4 will turn on.
+ *
+ */
+void functest()
+{
+    Pin pb0(0);
+    Pin pb1(1, true);
+    Pin pb2(2, true);
+    Pin pb4(4, false);
+    pb0.setDirection(Pin::DIRECTION_OUT);
+    pb1.setDirection(Pin::DIRECTION_IN);
+    pb2.setDirection(Pin::DIRECTION_OUT);
+    pb4.setDirection(Pin::DIRECTION_OUT);
+
+    while(true) {
+        if (pb1.read()) {
+            pb0.assert();
+            pb4.assert();
+            pb2.toggle();
+        } else {
+            pb0.deassert();
+            pb4.deassert();
+        }
+    }
+}

--- a/hal/common/include/junk/hal/ipin.h
+++ b/hal/common/include/junk/hal/ipin.h
@@ -24,6 +24,7 @@ public:
 
     virtual void setDirection( const Direction dir ) = 0;
     virtual bool read() const = 0;
+    virtual void set(bool asserted) = 0;
     virtual void assert() = 0;
     virtual void deassert() = 0;
     virtual void toggle() = 0;


### PR DESCRIPTION
- Adds functional tests for AVR ATTiny85 pin driver.
- Adds build system support for building and flashing
  AVR functional tests.
- Overhauls AVR build system to bring libs, unit tests, and func
  tests in line with each other. Cleans up lots of Makefile stuff.